### PR TITLE
[BUGFIX] EXT:form - Cover empty strings for "skipIfValueIsEmpty"

### DIFF
--- a/Documentation/ApiReference/Index.rst
+++ b/Documentation/ApiReference/Index.rst
@@ -2747,7 +2747,7 @@ elements.<formElementIdentifier>.skipIfValueIsEmpty
 
 :aspect:`Description`
       Set this to true if the database column should not be written if the value from the submitted form element with the identifier
-      `<formElementIdentifier>` is empty (think about password fields etc.)
+      `<formElementIdentifier>` is empty (think about password fields etc.). Empty means strings without content, whitespace is valid content.
 
 
 .. _apireference-finisheroptions-savetodatabasefinisher-options-elements-<formelementidentifier>-savefileidentifierinsteadofuid:

--- a/Documentation/Config/proto/finishersDefinition/finishers/SaveToDatabase.rst
+++ b/Documentation/Config/proto/finishersDefinition/finishers/SaveToDatabase.rst
@@ -251,7 +251,8 @@ options.elements.<formElementIdentifier>.mapOnDatabaseColumn.skipIfValueIsEmpty
 
 :aspect:`Description`
       Set this to true if the database column should not be written if the value from the submitted form element with the identifier
-      `<formElementIdentifier>` is empty (think about password fields etc.)
+      `<formElementIdentifier>` is empty (think about password fields etc.). Empty means strings without content, whitespace
+      is valid content.
 
 
 .. _typo3.cms.form.prototypes.<prototypeIdentifier>.finishersdefinition.savetodatabase.options.databasecolumnmappings:
@@ -347,7 +348,7 @@ options.databaseColumnMappings.<databaseColumnName>.skipIfValueIsEmpty
       - :ref:`"Accessing form runtime values"<concepts-frontendrendering-codecomponents-customfinisherimplementations-accessingoptions-formruntimeaccessor>`
 
 :aspect:`Description`
-      Set this to true if the database column should not be written if the value from `options.databaseColumnMappings.<databaseColumnName>.value` is empty.
+      Set this to true if the database column should not be written if the value from `options.databaseColumnMappings.<databaseColumnName>.value` is empty. Empty means strings without content, whitespace is valid content.
 
 
 .. _typo3.cms.form.prototypes.<prototypeIdentifier>.finishersdefinition.savetodatabase.options.translation.translationfile:


### PR DESCRIPTION
This ensures that e.g. unchecked checkboxes are not tried to be
stored in the database as empty strings causing an error on int
fields.

Resolves: #82938
Releases: master, 8.7
Change-Id: I6f1811b8fdf17de4c0dd1fac4dec8076600924c6