### PR TITLE
[FEATURE] EXT:form - add file size validator

### DIFF
--- a/Documentation/Config/configuration/Index.rst
+++ b/Documentation/Config/configuration/Index.rst
@@ -3334,9 +3334,46 @@ Full default configuration
                   validatorIdentifier: NotEmpty
                   propertyPath: properties.fluidAdditionalAttributes.required
                   propertyValue: required
+                900:
+                  identifier: 'validators'
+                  templateName: 'Inspector-ValidatorsEditor'
+                  label: 'formEditor.elements.FileUploadMixin.editor.validators.label'
+                  selectOptions:
+                    10:
+                      value: ''
+                      label: 'formEditor.elements.FileUploadMixin.editor.validators.EmptyValue.label'
+                    20:
+                      value: 'FileSize'
+                      label: 'formEditor.elements.FileUploadMixin.editor.validators.FileSize.label'
                 9999:
                   identifier: removeButton
                   templateName: Inspector-RemoveElementEditor
+              propertyCollections:
+                validators:
+                  10:
+                    identifier: FileSize
+                    editors:
+                      100:
+                        identifier: header
+                        templateName: Inspector-CollectionElementHeaderEditor
+                        label: formEditor.elements.FileUploadMixin.validators.FileSize.editor.header.label
+                      200:
+                        identifier: minimum
+                        templateName: Inspector-TextEditor
+                        label: formEditor.elements.MinimumMaximumEditorsMixin.editor.minimum.label
+                        propertyPath: options.minimum
+                        propertyValidators:
+                          10: FileSize
+                      300:
+                        identifier: maximum
+                        templateName: Inspector-TextEditor
+                        label: formEditor.elements.MinimumMaximumEditorsMixin.editor.maximum.label
+                        propertyPath: options.maximum
+                        propertyValidators:
+                          10: FileSize
+                      9999:
+                        identifier: removeButton
+                        templateName: Inspector-RemoveElementEditor
               predefinedDefaults:
                 properties:
                   saveToFileMount: '1:/user_upload/'
@@ -3421,9 +3458,46 @@ Full default configuration
                   validatorIdentifier: NotEmpty
                   propertyPath: properties.fluidAdditionalAttributes.required
                   propertyValue: required
+                900:
+                  identifier: 'validators'
+                  templateName: 'Inspector-ValidatorsEditor'
+                  label: 'formEditor.elements.FileUploadMixin.editor.validators.label'
+                  selectOptions:
+                    10:
+                      value: ''
+                      label: 'formEditor.elements.FileUploadMixin.editor.validators.EmptyValue.label'
+                    20:
+                      value: 'FileSize'
+                      label: 'formEditor.elements.FileUploadMixin.editor.validators.FileSize.label'
                 9999:
                   identifier: removeButton
                   templateName: Inspector-RemoveElementEditor
+              propertyCollections:
+                validators:
+                  10:
+                    identifier: FileSize
+                    editors:
+                      100:
+                        identifier: header
+                        templateName: Inspector-CollectionElementHeaderEditor
+                        label: formEditor.elements.FileUploadMixin.validators.FileSize.editor.header.label
+                      200:
+                        identifier: minimum
+                        templateName: Inspector-TextEditor
+                        label: formEditor.elements.MinimumMaximumEditorsMixin.editor.minimum.label
+                        propertyPath: options.minimum
+                        propertyValidators:
+                          10: FileSize
+                      300:
+                        identifier: maximum
+                        templateName: Inspector-TextEditor
+                        label: formEditor.elements.MinimumMaximumEditorsMixin.editor.maximum.label
+                        propertyPath: options.maximum
+                        propertyValidators:
+                          10: FileSize
+                      9999:
+                        identifier: removeButton
+                        templateName: Inspector-RemoveElementEditor
               predefinedDefaults:
                 properties:
                   saveToFileMount: '1:/user_upload/'
@@ -3748,6 +3822,16 @@ Full default configuration
                 options:
                   minimum: ''
                   maximum: ''
+          FileSize:
+            implementationClassName: TYPO3\CMS\Form\Mvc\Validation\FileSizeValidator
+            formEditor:
+              iconIdentifier: 't3-form-icon-validator'
+              label: 'formEditor.elements.FileUploadMixin.validators.FileSize.editor.header.label'
+              predefinedDefaults:
+                options:
+                  minimum: '0B'
+                  maximum: '10M'
+
         formEditor:
           translationFile: 'EXT:form/Resources/Private/Language/Database.xlf'
           dynamicRequireJsModules:

--- a/Documentation/Config/proto/formElements/formElementTypes/FileUpload.rst
+++ b/Documentation/Config/proto/formElements/formElementTypes/FileUpload.rst
@@ -51,11 +51,32 @@ Properties
 .. _typo3.cms.form.prototypes.<prototypeIdentifier>.formelementsdefinition.fileupload.formeditor.editors.800:
 .. include:: FileUpload/formEditor/editors/800.txt
 
+.. _typo3.cms.form.prototypes.<prototypeIdentifier>.formelementsdefinition.fileupload.formeditor.editors.900:
+.. include:: FileUpload/formEditor/editors/900.txt
+
 .. _typo3.cms.form.prototypes.<prototypeIdentifier>.formelementsdefinition.fileupload.formeditor.editors.9999:
 .. include:: FileUpload/formEditor/editors/9999.txt
 
 .. _typo3.cms.form.prototypes.<prototypeIdentifier>.formelementsdefinition.fileupload.formeditor.predefineddefaults:
 .. include:: FileUpload/formEditor/predefinedDefaults.txt
+
+.. _typo3.cms.form.prototypes.<prototypeIdentifier>.formelementsdefinition.fileupload.formeditor.propertycollections.validators.10:
+.. include:: FileUpload/formEditor/propertyCollections/validators/10.txt
+
+.. _typo3.cms.form.prototypes.<prototypeIdentifier>.formelementsdefinition.fileupload.formeditor.propertycollections.validators.10.identifier:
+.. include:: FileUpload/formEditor/propertyCollections/validators/10/identifier.txt
+
+.. _typo3.cms.form.prototypes.<prototypeIdentifier>.formelementsdefinition.fileupload.formeditor.propertycollections.validators.10.editors.100:
+.. include:: FileUpload/formEditor/propertyCollections/validators/10/editors/100.txt
+
+.. _typo3.cms.form.prototypes.<prototypeIdentifier>.formelementsdefinition.fileupload.formeditor.propertycollections.validators.10.editors.200:
+.. include:: FileUpload/formEditor/propertyCollections/validators/10/editors/200.txt
+
+.. _typo3.cms.form.prototypes.<prototypeIdentifier>.formelementsdefinition.fileupload.formeditor.propertycollections.validators.10.editors.300:
+.. include:: FileUpload/formEditor/propertyCollections/validators/10/editors/300.txt
+
+.. _typo3.cms.form.prototypes.<prototypeIdentifier>.formelementsdefinition.fileupload.formeditor.propertycollections.validators.10.editors.9999:
+.. include:: FileUpload/formEditor/propertyCollections/validators/10/editors/9999.txt
 
 .. _typo3.cms.form.prototypes.<prototypeIdentifier>.formelementsdefinition.fileupload.formeditor.label:
 .. include:: FileUpload/formEditor/label.txt

--- a/Documentation/Config/proto/formElements/formElementTypes/FileUpload/formEditor.txt
+++ b/Documentation/Config/proto/formElements/formElementTypes/FileUpload/formEditor.txt
@@ -94,9 +94,46 @@ formEditor
                  validatorIdentifier: NotEmpty
                  propertyPath: properties.fluidAdditionalAttributes.required
                  propertyValue: required
+               900:
+                 identifier: 'validators'
+                 templateName: 'Inspector-ValidatorsEditor'
+                 label: 'formEditor.elements.FileUploadMixin.editor.validators.label'
+                 selectOptions:
+                   10:
+                     value: ''
+                     label: 'formEditor.elements.FileUploadMixin.editor.validators.EmptyValue.label'
+                   20:
+                     value: 'FileSize'
+                     label: 'formEditor.elements.FileUploadMixin.editor.validators.FileSize.label'
                9999:
                  identifier: removeButton
                  templateName: Inspector-RemoveElementEditor
+             propertyCollections:
+               validators:
+                 10:
+                   identifier: FileSize
+                   editors:
+                     100:
+                       identifier: header
+                       templateName: Inspector-CollectionElementHeaderEditor
+                       label: formEditor.elements.FileUploadMixin.validators.FileSize.editor.header.label
+                     200:
+                       identifier: minimum
+                       templateName: Inspector-TextEditor
+                       label: formEditor.elements.MinimumMaximumEditorsMixin.editor.minimum.label
+                       propertyPath: options.minimum
+                       propertyValidators:
+                         10: FileSize
+                     300:
+                       identifier: maximum
+                       templateName: Inspector-TextEditor
+                       label: formEditor.elements.MinimumMaximumEditorsMixin.editor.maximum.label
+                       propertyPath: options.maximum
+                       propertyValidators:
+                         10: FileSize
+                     9999:
+                       identifier: removeButton
+                       templateName: Inspector-RemoveElementEditor
              predefinedDefaults:
                properties:
                  saveToFileMount: '1:/user_upload/'

--- a/Documentation/Config/proto/formElements/formElementTypes/FileUpload/formEditor/editors/400.txt
+++ b/Documentation/Config/proto/formElements/formElementTypes/FileUpload/formEditor/editors/400.txt
@@ -33,4 +33,3 @@ formEditor.editors.400
                    10:
                      value: '1:/user_upload/'
                      label: '1:/user_upload/'
-

--- a/Documentation/Config/proto/formElements/formElementTypes/FileUpload/formEditor/editors/700.txt
+++ b/Documentation/Config/proto/formElements/formElementTypes/FileUpload/formEditor/editors/700.txt
@@ -46,4 +46,3 @@ formEditor.editors.700
                      label: formEditor.elements.FormElement.editor.gridColumnViewPortConfiguration.numbersOfColumnsToUse.label
                      propertyPath: 'properties.gridColumnClassAutoConfiguration.viewPorts.{@viewPortIdentifier}.numbersOfColumnsToUse'
                      fieldExplanationText: formEditor.elements.FormElement.editor.gridColumnViewPortConfiguration.numbersOfColumnsToUse.fieldExplanationText
-

--- a/Documentation/Config/proto/formElements/formElementTypes/FileUpload/formEditor/editors/800.txt
+++ b/Documentation/Config/proto/formElements/formElementTypes/FileUpload/formEditor/editors/800.txt
@@ -31,5 +31,3 @@ formEditor.editors.800
                  validatorIdentifier: NotEmpty
                  propertyPath: properties.fluidAdditionalAttributes.required
                  propertyValue: required
-
-

--- a/Documentation/Config/proto/formElements/formElementTypes/FileUpload/formEditor/editors/900.txt
+++ b/Documentation/Config/proto/formElements/formElementTypes/FileUpload/formEditor/editors/900.txt
@@ -1,0 +1,37 @@
+formEditor.editors.900
+----------------------
+
+:aspect:`Option path`
+      TYPO3.CMS.Form.prototypes.<prototypeIdentifier>.formElementsDefinition.FileUpload.formEditor.editors.900
+
+:aspect:`Data type`
+      array/ :ref:`[ValidatorsEditor] <typo3.cms.form.prototypes.\<prototypeidentifier>.formelementsdefinition.\<formelementtypeidentifier>.formeditor.editors.*.validatorseditor>`
+
+:aspect:`Needed by`
+      Backend (form editor)
+
+:aspect:`Mandatory`
+      Recommended
+
+.. :aspect:`Related options`
+      @ToDo
+
+:aspect:`Default value (for prototype 'standard')`
+      .. code-block:: yaml
+         :linenos:
+         :emphasize-lines: 4-
+
+         FileUpload:
+           formEditor:
+             editors:
+               900:
+                 identifier: validators
+                 templateName: Inspector-ValidatorsEditor
+                 label: formEditor.elements.FileUploadMixin.editor.validators.label
+                 selectOptions:
+                   10:
+                     value: ''
+                     label: formEditor.elements.FileUploadMixin.editor.validators.EmptyValue.label
+                   20:
+                     value: FileSize
+                     label: formEditor.elements.FileUploadMixin.editor.validators.FileSize.label

--- a/Documentation/Config/proto/formElements/formElementTypes/FileUpload/formEditor/editors/9999.txt
+++ b/Documentation/Config/proto/formElements/formElementTypes/FileUpload/formEditor/editors/9999.txt
@@ -27,4 +27,3 @@ formEditor.editors.9999
                9999:
                  identifier: removeButton
                  templateName: Inspector-RemoveElementEditor
-

--- a/Documentation/Config/proto/formElements/formElementTypes/FileUpload/formEditor/propertyCollections/validators/10.txt
+++ b/Documentation/Config/proto/formElements/formElementTypes/FileUpload/formEditor/propertyCollections/validators/10.txt
@@ -1,0 +1,48 @@
+formEditor.propertyCollections.validators.10
+--------------------------------------------
+
+:aspect:`Option path`
+      TYPO3.CMS.Form.prototypes.<prototypeIdentifier>.formElementsDefinition.FileUpload.formEditor.propertyCollections.validators.10
+
+:aspect:`Data type`
+      array
+
+:aspect:`Needed by`
+      Backend (form editor)
+
+:aspect:`Mandatory`
+      No
+
+:aspect:`Default value (for prototype 'standard')`
+      .. code-block:: yaml
+         :linenos:
+         :emphasize-lines: 5-
+
+         FileUpload:
+           formEditor:
+             propertyCollections:
+               validators:
+                 10:
+                   identifier: FileSize
+                   editors:
+                     100:
+                       identifier: header
+                       templateName: Inspector-CollectionElementHeaderEditor
+                       label: formEditor.elements.FileUploadMixin.validators.FileSize.editor.header.label
+                     200:
+                       identifier: minimum
+                       templateName: Inspector-TextEditor
+                       label: formEditor.elements.MinimumMaximumEditorsMixin.editor.minimum.label
+                       propertyPath: options.minimum
+                       propertyValidators:
+                         10: FileSize
+                     300:
+                       identifier: maximum
+                       templateName: Inspector-TextEditor
+                       label: formEditor.elements.MinimumMaximumEditorsMixin.editor.maximum.label
+                       propertyPath: options.maximum
+                       propertyValidators:
+                         10: FileSize
+                     9999:
+                       identifier: removeButton
+                       templateName: Inspector-RemoveElementEditor

--- a/Documentation/Config/proto/formElements/formElementTypes/FileUpload/formEditor/propertyCollections/validators/10/editors/100.txt
+++ b/Documentation/Config/proto/formElements/formElementTypes/FileUpload/formEditor/propertyCollections/validators/10/editors/100.txt
@@ -1,0 +1,31 @@
+formEditor.propertyCollections.validators.10.editors.100
+--------------------------------------------------------
+
+:aspect:`Option path`
+      TYPO3.CMS.Form.prototypes.<prototypeIdentifier>.formElementsDefinition.FileUpload.formEditor.propertyCollections.validators.10.editors.100
+
+:aspect:`Data type`
+      array/ :ref:`[CollectionElementHeaderEditor] <typo3.cms.form.prototypes.\<prototypeidentifier>.formelementsdefinition.\<formelementtypeidentifier>.formeditor.editors.*.collectionelementheadereditor>`
+
+:aspect:`Needed by`
+      Backend (form editor)
+
+:aspect:`Mandatory`
+      Recommended
+
+:aspect:`Default value (for prototype 'standard')`
+      .. code-block:: yaml
+         :linenos:
+         :emphasize-lines: 8-
+
+         FileUpload:
+           formEditor:
+             propertyCollections:
+               validators:
+                 10:
+                   identifier: FileSize
+                   editors:
+                     100:
+                       identifier: header
+                       templateName: Inspector-CollectionElementHeaderEditor
+                       label: formEditor.elements.FileUploadMixin.validators.FileSize.editor.header.label

--- a/Documentation/Config/proto/formElements/formElementTypes/FileUpload/formEditor/propertyCollections/validators/10/editors/200.txt
+++ b/Documentation/Config/proto/formElements/formElementTypes/FileUpload/formEditor/propertyCollections/validators/10/editors/200.txt
@@ -1,0 +1,34 @@
+formEditor.propertyCollections.validators.10.editors.100
+--------------------------------------------------------
+
+:aspect:`Option path`
+      TYPO3.CMS.Form.prototypes.<prototypeIdentifier>.formElementsDefinition.FileUpload.formEditor.propertyCollections.validators.10.editors.100
+
+:aspect:`Data type`
+      array/ :ref:`[CollectionElementHeaderEditor] <typo3.cms.form.prototypes.\<prototypeidentifier>.formelementsdefinition.\<formelementtypeidentifier>.formeditor.editors.*.collectionelementheadereditor>`
+
+:aspect:`Needed by`
+      Backend (form editor)
+
+:aspect:`Mandatory`
+      Recommended
+
+:aspect:`Default value (for prototype 'standard')`
+      .. code-block:: yaml
+         :linenos:
+         :emphasize-lines: 8-
+
+         FileUpload:
+           formEditor:
+             propertyCollections:
+               validators:
+                 10:
+                   identifier: FileSize
+                   editors:
+                     200:
+                       identifier: minimum
+                       templateName: Inspector-TextEditor
+                       label: formEditor.elements.MinimumMaximumEditorsMixin.editor.minimum.label
+                       propertyPath: options.minimum
+                       propertyValidators:
+                         10: FileSize

--- a/Documentation/Config/proto/formElements/formElementTypes/FileUpload/formEditor/propertyCollections/validators/10/editors/300.txt
+++ b/Documentation/Config/proto/formElements/formElementTypes/FileUpload/formEditor/propertyCollections/validators/10/editors/300.txt
@@ -1,0 +1,34 @@
+formEditor.propertyCollections.validators.10.editors.100
+--------------------------------------------------------
+
+:aspect:`Option path`
+      TYPO3.CMS.Form.prototypes.<prototypeIdentifier>.formElementsDefinition.FileUpload.formEditor.propertyCollections.validators.10.editors.100
+
+:aspect:`Data type`
+      array/ :ref:`[CollectionElementHeaderEditor] <typo3.cms.form.prototypes.\<prototypeidentifier>.formelementsdefinition.\<formelementtypeidentifier>.formeditor.editors.*.collectionelementheadereditor>`
+
+:aspect:`Needed by`
+      Backend (form editor)
+
+:aspect:`Mandatory`
+      Recommended
+
+:aspect:`Default value (for prototype 'standard')`
+      .. code-block:: yaml
+         :linenos:
+         :emphasize-lines: 8-
+
+         FileUpload:
+           formEditor:
+             propertyCollections:
+               validators:
+                 10:
+                   identifier: FileSize
+                   editors:
+                     300:
+                       identifier: maximum
+                       templateName: Inspector-TextEditor
+                       label: formEditor.elements.MinimumMaximumEditorsMixin.editor.maximum.label
+                       propertyPath: options.maximum
+                       propertyValidators:
+                         10: FileSize

--- a/Documentation/Config/proto/formElements/formElementTypes/FileUpload/formEditor/propertyCollections/validators/10/editors/9999.txt
+++ b/Documentation/Config/proto/formElements/formElementTypes/FileUpload/formEditor/propertyCollections/validators/10/editors/9999.txt
@@ -1,0 +1,30 @@
+formEditor.propertyCollections.validators.10.editors.9999
+---------------------------------------------------------
+
+:aspect:`Option path`
+      TYPO3.CMS.Form.prototypes.<prototypeIdentifier>.formElementsDefinition.FileUpload.formEditor.propertyCollections.validators.10.editors.9999
+
+:aspect:`Data type`
+      array/ :ref:`[RemoveElementEditor] <typo3.cms.form.prototypes.\<prototypeidentifier>.formelementsdefinition.\<formelementtypeidentifier>.formeditor.editors.*.removeelementeditor>`
+
+:aspect:`Needed by`
+      Backend (form editor)
+
+:aspect:`Mandatory`
+      Recommended
+
+:aspect:`Default value (for prototype 'standard')`
+      .. code-block:: yaml
+         :linenos:
+         :emphasize-lines: 8-
+
+         FileUpload:
+           formEditor:
+             propertyCollections:
+               validators:
+                 10:
+                   identifier: FileSize
+                   editors:
+                     9999:
+                       identifier: removeButton
+                       templateName: Inspector-RemoveElementEditor

--- a/Documentation/Config/proto/formElements/formElementTypes/FileUpload/formEditor/propertyCollections/validators/10/identifier.txt
+++ b/Documentation/Config/proto/formElements/formElementTypes/FileUpload/formEditor/propertyCollections/validators/10/identifier.txt
@@ -1,0 +1,33 @@
+formEditor.propertyCollections.validators.10.identifier
+-------------------------------------------------------
+
+:aspect:`Option path`
+      TYPO3.CMS.Form.prototypes.<prototypeIdentifier>.formElementsDefinition.FileUpload.formEditor.propertyCollections.validators.10.identifier
+
+:aspect:`Data type`
+      string
+
+:aspect:`Needed by`
+      Backend (form editor)
+
+:aspect:`Mandatory`
+      Yes
+
+:aspect:`Default value (for prototype 'standard')`
+      .. code-block:: yaml
+         :linenos:
+         :emphasize-lines: 6
+
+         FileUpload:
+           formEditor:
+             propertyCollections:
+               validators:
+                 10:
+                   identifier: FileSize
+
+:aspect:`Good to know`
+      - :ref:`"Inspector"<concepts-formeditor-inspector>`
+      - :ref:`"\<validatorIdentifier>"<typo3.cms.form.prototypes.\<prototypeidentifier>.validatorsdefinition.\<validatoridentifier>>`
+
+:aspect:`Description`
+      Identifies the validator which should be attached to the form element. Must be equal to a existing ``<validatorIdentifier>``.

--- a/Documentation/Config/proto/formElements/formElementTypes/ImageUpload.rst
+++ b/Documentation/Config/proto/formElements/formElementTypes/ImageUpload.rst
@@ -60,11 +60,32 @@ Properties
 .. _typo3.cms.form.prototypes.<prototypeIdentifier>.formelementsdefinition.imageupload.formeditor.editors.800:
 .. include:: ImageUpload/formEditor/editors/800.txt
 
+.. _typo3.cms.form.prototypes.<prototypeIdentifier>.formelementsdefinition.imageupload.formeditor.editors.900:
+.. include:: ImageUpload/formEditor/editors/900.txt
+
 .. _typo3.cms.form.prototypes.<prototypeIdentifier>.formelementsdefinition.imageupload.formeditor.editors.9999:
 .. include:: ImageUpload/formEditor/editors/9999.txt
 
 .. _typo3.cms.form.prototypes.<prototypeIdentifier>.formelementsdefinition.imageupload.formeditor.predefineddefaults:
 .. include:: ImageUpload/formEditor/predefinedDefaults.txt
+
+.. _typo3.cms.form.prototypes.<prototypeIdentifier>.formelementsdefinition.imageupload.formeditor.propertycollections.validators.10:
+.. include:: ImageUpload/formEditor/propertyCollections/validators/10.txt
+
+.. _typo3.cms.form.prototypes.<prototypeIdentifier>.formelementsdefinition.imageupload.formeditor.propertycollections.validators.10.identifier:
+.. include:: ImageUpload/formEditor/propertyCollections/validators/10/identifier.txt
+
+.. _typo3.cms.form.prototypes.<prototypeIdentifier>.formelementsdefinition.imageupload.formeditor.propertycollections.validators.10.editors.100:
+.. include:: ImageUpload/formEditor/propertyCollections/validators/10/editors/100.txt
+
+.. _typo3.cms.form.prototypes.<prototypeIdentifier>.formelementsdefinition.imageupload.formeditor.propertycollections.validators.10.editors.200:
+.. include:: ImageUpload/formEditor/propertyCollections/validators/10/editors/200.txt
+
+.. _typo3.cms.form.prototypes.<prototypeIdentifier>.formelementsdefinition.imageupload.formeditor.propertycollections.validators.10.editors.300:
+.. include:: ImageUpload/formEditor/propertyCollections/validators/10/editors/300.txt
+
+.. _typo3.cms.form.prototypes.<prototypeIdentifier>.formelementsdefinition.imageupload.formeditor.propertycollections.validators.10.editors.9999:
+.. include:: ImageUpload/formEditor/propertyCollections/validators/10/editors/9999.txt
 
 .. _typo3.cms.form.prototypes.<prototypeIdentifier>.formelementsdefinition.imageupload.formeditor.label:
 .. include:: ImageUpload/formEditor/label.txt

--- a/Documentation/Config/proto/formElements/formElementTypes/ImageUpload/formEditor.txt
+++ b/Documentation/Config/proto/formElements/formElementTypes/ImageUpload/formEditor.txt
@@ -82,9 +82,46 @@ formEditor
                  validatorIdentifier: NotEmpty
                  propertyPath: properties.fluidAdditionalAttributes.required
                  propertyValue: required
+               900:
+                 identifier: 'validators'
+                 templateName: 'Inspector-ValidatorsEditor'
+                 label: 'formEditor.elements.FileUploadMixin.editor.validators.label'
+                 selectOptions:
+                   10:
+                     value: ''
+                     label: 'formEditor.elements.FileUploadMixin.editor.validators.EmptyValue.label'
+                   20:
+                     value: 'FileSize'
+                     label: 'formEditor.elements.FileUploadMixin.editor.validators.FileSize.label'
                9999:
                  identifier: removeButton
                  templateName: Inspector-RemoveElementEditor
+             propertyCollections:
+               validators:
+                 10:
+                   identifier: FileSize
+                   editors:
+                     100:
+                       identifier: header
+                       templateName: Inspector-CollectionElementHeaderEditor
+                       label: formEditor.elements.FileUploadMixin.validators.FileSize.editor.header.label
+                     200:
+                       identifier: minimum
+                       templateName: Inspector-TextEditor
+                       label: formEditor.elements.MinimumMaximumEditorsMixin.editor.minimum.label
+                       propertyPath: options.minimum
+                       propertyValidators:
+                         10: FileSize
+                     300:
+                       identifier: maximum
+                       templateName: Inspector-TextEditor
+                       label: formEditor.elements.MinimumMaximumEditorsMixin.editor.maximum.label
+                       propertyPath: options.maximum
+                       propertyValidators:
+                         10: FileSize
+                     9999:
+                       identifier: removeButton
+                       templateName: Inspector-RemoveElementEditor
              predefinedDefaults:
                properties:
                  saveToFileMount: '1:/user_upload/'

--- a/Documentation/Config/proto/formElements/formElementTypes/ImageUpload/formEditor/editors/900.txt
+++ b/Documentation/Config/proto/formElements/formElementTypes/ImageUpload/formEditor/editors/900.txt
@@ -1,0 +1,37 @@
+formEditor.editors.900
+----------------------
+
+:aspect:`Option path`
+      TYPO3.CMS.Form.prototypes.<prototypeIdentifier>.formElementsDefinition.ImageUpload.formEditor.editors.900
+
+:aspect:`Data type`
+      array/ :ref:`[ValidatorsEditor] <typo3.cms.form.prototypes.\<prototypeidentifier>.formelementsdefinition.\<formelementtypeidentifier>.formeditor.editors.*.validatorseditor>`
+
+:aspect:`Needed by`
+      Backend (form editor)
+
+:aspect:`Mandatory`
+      Recommended
+
+.. :aspect:`Related options`
+      @ToDo
+
+:aspect:`Default value (for prototype 'standard')`
+      .. code-block:: yaml
+         :linenos:
+         :emphasize-lines: 4-
+
+         ImageUpload:
+           formEditor:
+             editors:
+               900:
+                 identifier: validators
+                 templateName: Inspector-ValidatorsEditor
+                 label: formEditor.elements.FileUploadMixin.editor.validators.label
+                 selectOptions:
+                   10:
+                     value: ''
+                     label: formEditor.elements.FileUploadMixin.editor.validators.EmptyValue.label
+                   20:
+                     value: FileSize
+                     label: formEditor.elements.FileUploadMixin.editor.validators.FileSize.label

--- a/Documentation/Config/proto/formElements/formElementTypes/ImageUpload/formEditor/propertyCollections/validators/10.txt
+++ b/Documentation/Config/proto/formElements/formElementTypes/ImageUpload/formEditor/propertyCollections/validators/10.txt
@@ -1,0 +1,48 @@
+formEditor.propertyCollections.validators.10
+--------------------------------------------
+
+:aspect:`Option path`
+      TYPO3.CMS.Form.prototypes.<prototypeIdentifier>.formElementsDefinition.ImageUpload.formEditor.propertyCollections.validators.10
+
+:aspect:`Data type`
+      array
+
+:aspect:`Needed by`
+      Backend (form editor)
+
+:aspect:`Mandatory`
+      No
+
+:aspect:`Default value (for prototype 'standard')`
+      .. code-block:: yaml
+         :linenos:
+         :emphasize-lines: 5-
+
+         ImageUpload:
+           formEditor:
+             propertyCollections:
+               validators:
+                 10:
+                   identifier: FileSize
+                   editors:
+                     100:
+                       identifier: header
+                       templateName: Inspector-CollectionElementHeaderEditor
+                       label: formEditor.elements.FileUploadMixin.validators.FileSize.editor.header.label
+                     200:
+                       identifier: minimum
+                       templateName: Inspector-TextEditor
+                       label: formEditor.elements.MinimumMaximumEditorsMixin.editor.minimum.label
+                       propertyPath: options.minimum
+                       propertyValidators:
+                         10: FileSize
+                     300:
+                       identifier: maximum
+                       templateName: Inspector-TextEditor
+                       label: formEditor.elements.MinimumMaximumEditorsMixin.editor.maximum.label
+                       propertyPath: options.maximum
+                       propertyValidators:
+                         10: FileSize
+                     9999:
+                       identifier: removeButton
+                       templateName: Inspector-RemoveElementEditor

--- a/Documentation/Config/proto/formElements/formElementTypes/ImageUpload/formEditor/propertyCollections/validators/10/editors/100.txt
+++ b/Documentation/Config/proto/formElements/formElementTypes/ImageUpload/formEditor/propertyCollections/validators/10/editors/100.txt
@@ -1,0 +1,31 @@
+formEditor.propertyCollections.validators.10.editors.100
+--------------------------------------------------------
+
+:aspect:`Option path`
+      TYPO3.CMS.Form.prototypes.<prototypeIdentifier>.formElementsDefinition.ImageUpload.formEditor.propertyCollections.validators.10.editors.100
+
+:aspect:`Data type`
+      array/ :ref:`[CollectionElementHeaderEditor] <typo3.cms.form.prototypes.\<prototypeidentifier>.formelementsdefinition.\<formelementtypeidentifier>.formeditor.editors.*.collectionelementheadereditor>`
+
+:aspect:`Needed by`
+      Backend (form editor)
+
+:aspect:`Mandatory`
+      Recommended
+
+:aspect:`Default value (for prototype 'standard')`
+      .. code-block:: yaml
+         :linenos:
+         :emphasize-lines: 8-
+
+         ImageUpload:
+           formEditor:
+             propertyCollections:
+               validators:
+                 10:
+                   identifier: FileSize
+                   editors:
+                     100:
+                       identifier: header
+                       templateName: Inspector-CollectionElementHeaderEditor
+                       label: formEditor.elements.FileUploadMixin.validators.FileSize.editor.header.label

--- a/Documentation/Config/proto/formElements/formElementTypes/ImageUpload/formEditor/propertyCollections/validators/10/editors/200.txt
+++ b/Documentation/Config/proto/formElements/formElementTypes/ImageUpload/formEditor/propertyCollections/validators/10/editors/200.txt
@@ -1,0 +1,34 @@
+formEditor.propertyCollections.validators.10.editors.100
+--------------------------------------------------------
+
+:aspect:`Option path`
+      TYPO3.CMS.Form.prototypes.<prototypeIdentifier>.formElementsDefinition.ImageUpload.formEditor.propertyCollections.validators.10.editors.100
+
+:aspect:`Data type`
+      array/ :ref:`[CollectionElementHeaderEditor] <typo3.cms.form.prototypes.\<prototypeidentifier>.formelementsdefinition.\<formelementtypeidentifier>.formeditor.editors.*.collectionelementheadereditor>`
+
+:aspect:`Needed by`
+      Backend (form editor)
+
+:aspect:`Mandatory`
+      Recommended
+
+:aspect:`Default value (for prototype 'standard')`
+      .. code-block:: yaml
+         :linenos:
+         :emphasize-lines: 8-
+
+         ImageUpload:
+           formEditor:
+             propertyCollections:
+               validators:
+                 10:
+                   identifier: FileSize
+                   editors:
+                     200:
+                       identifier: minimum
+                       templateName: Inspector-TextEditor
+                       label: formEditor.elements.MinimumMaximumEditorsMixin.editor.minimum.label
+                       propertyPath: options.minimum
+                       propertyValidators:
+                         10: FileSize

--- a/Documentation/Config/proto/formElements/formElementTypes/ImageUpload/formEditor/propertyCollections/validators/10/editors/300.txt
+++ b/Documentation/Config/proto/formElements/formElementTypes/ImageUpload/formEditor/propertyCollections/validators/10/editors/300.txt
@@ -1,0 +1,34 @@
+formEditor.propertyCollections.validators.10.editors.100
+--------------------------------------------------------
+
+:aspect:`Option path`
+      TYPO3.CMS.Form.prototypes.<prototypeIdentifier>.formElementsDefinition.ImageUpload.formEditor.propertyCollections.validators.10.editors.100
+
+:aspect:`Data type`
+      array/ :ref:`[CollectionElementHeaderEditor] <typo3.cms.form.prototypes.\<prototypeidentifier>.formelementsdefinition.\<formelementtypeidentifier>.formeditor.editors.*.collectionelementheadereditor>`
+
+:aspect:`Needed by`
+      Backend (form editor)
+
+:aspect:`Mandatory`
+      Recommended
+
+:aspect:`Default value (for prototype 'standard')`
+      .. code-block:: yaml
+         :linenos:
+         :emphasize-lines: 8-
+
+         ImageUpload:
+           formEditor:
+             propertyCollections:
+               validators:
+                 10:
+                   identifier: FileSize
+                   editors:
+                     300:
+                       identifier: maximum
+                       templateName: Inspector-TextEditor
+                       label: formEditor.elements.MinimumMaximumEditorsMixin.editor.maximum.label
+                       propertyPath: options.maximum
+                       propertyValidators:
+                         10: FileSize

--- a/Documentation/Config/proto/formElements/formElementTypes/ImageUpload/formEditor/propertyCollections/validators/10/editors/9999.txt
+++ b/Documentation/Config/proto/formElements/formElementTypes/ImageUpload/formEditor/propertyCollections/validators/10/editors/9999.txt
@@ -1,0 +1,30 @@
+formEditor.propertyCollections.validators.10.editors.9999
+---------------------------------------------------------
+
+:aspect:`Option path`
+      TYPO3.CMS.Form.prototypes.<prototypeIdentifier>.formElementsDefinition.ImageUpload.formEditor.propertyCollections.validators.10.editors.9999
+
+:aspect:`Data type`
+      array/ :ref:`[RemoveElementEditor] <typo3.cms.form.prototypes.\<prototypeidentifier>.formelementsdefinition.\<formelementtypeidentifier>.formeditor.editors.*.removeelementeditor>`
+
+:aspect:`Needed by`
+      Backend (form editor)
+
+:aspect:`Mandatory`
+      Recommended
+
+:aspect:`Default value (for prototype 'standard')`
+      .. code-block:: yaml
+         :linenos:
+         :emphasize-lines: 8-
+
+         ImageUpload:
+           formEditor:
+             propertyCollections:
+               validators:
+                 10:
+                   identifier: FileSize
+                   editors:
+                     9999:
+                       identifier: removeButton
+                       templateName: Inspector-RemoveElementEditor

--- a/Documentation/Config/proto/formElements/formElementTypes/ImageUpload/formEditor/propertyCollections/validators/10/identifier.txt
+++ b/Documentation/Config/proto/formElements/formElementTypes/ImageUpload/formEditor/propertyCollections/validators/10/identifier.txt
@@ -1,0 +1,33 @@
+formEditor.propertyCollections.validators.10.identifier
+-------------------------------------------------------
+
+:aspect:`Option path`
+      TYPO3.CMS.Form.prototypes.<prototypeIdentifier>.formElementsDefinition.ImageUpload.formEditor.propertyCollections.validators.10.identifier
+
+:aspect:`Data type`
+      string
+
+:aspect:`Needed by`
+      Backend (form editor)
+
+:aspect:`Mandatory`
+      Yes
+
+:aspect:`Default value (for prototype 'standard')`
+      .. code-block:: yaml
+         :linenos:
+         :emphasize-lines: 6
+
+         ImageUpload:
+           formEditor:
+             propertyCollections:
+               validators:
+                 10:
+                   identifier: FileSize
+
+:aspect:`Good to know`
+      - :ref:`"Inspector"<concepts-formeditor-inspector>`
+      - :ref:`"\<validatorIdentifier>"<typo3.cms.form.prototypes.\<prototypeidentifier>.validatorsdefinition.\<validatoridentifier>>`
+
+:aspect:`Description`
+      Identifies the validator which should be attached to the form element. Must be equal to a existing ``<validatorIdentifier>``.

--- a/Documentation/Config/proto/validatorsDefinition/Index.rst
+++ b/Documentation/Config/proto/validatorsDefinition/Index.rst
@@ -92,6 +92,8 @@ Properties
                [...]
              Count:
                [...]
+             FileSize:
+               [...]
 
 :aspect:`Related options`
       - :ref:`"TYPO3.CMS.Form.prototypes.\<prototypeIdentifier>.formElementsDefinition.\<formElementTypeIdentifier>.formEditor.propertyCollections.validators.[*].identifier"<typo3.cms.form.prototypes.\<prototypeIdentifier>.formelementsdefinition.\<formelementtypeidentifier>.formeditor.propertycollections.validators.*.identifier>`
@@ -291,3 +293,4 @@ Concrete configurations
     validators/RegularExpression
     validators/StringLength
     validators/Text
+    validators/FileSize

--- a/Documentation/Config/proto/validatorsDefinition/validators/FileSize.rst
+++ b/Documentation/Config/proto/validatorsDefinition/validators/FileSize.rst
@@ -1,0 +1,207 @@
+.. include:: ../../../../Includes.txt
+
+
+.. _typo3.cms.form.prototypes.validatorsdefinition.filesize:
+
+==========
+[FileSize]
+==========
+
+
+.. _typo3.cms.form.prototypes.<prototypeidentifier>.validatorsdefinition.filesize-validationerrorcodes:
+
+validation error codes
+======================
+
+- 1505303626
+- 1505305752
+- 1505305753
+
+.. _typo3.cms.form.prototypes.<prototypeidentifier>.validatorsdefinition.filesize-properties:
+
+Properties
+==========
+
+
+.. _typo3.cms.form.prototypes.<prototypeidentifier>.validatorsdefinition.filesize.implementationClassName:
+
+implementationClassName
+-----------------------
+
+:aspect:`Option path`
+      TYPO3.CMS.Form.prototypes.<prototypeIdentifier>.validatorsDefinition.FileSize.implementationClassName
+
+:aspect:`Data type`
+      string
+
+:aspect:`Needed by`
+      Frontend
+
+:aspect:`Mandatory`
+      Yes
+
+:aspect:`Default value (for prototype 'standard')`
+      .. code-block:: yaml
+         :linenos:
+             :emphasize-lines: 2
+
+             FileSize:
+               implementationClassName: TYPO3\CMS\Form\Mvc\Validation\FileSizeValidator
+
+:aspect:`Good to know`
+      - :ref:`"Custom validator implementations"<concepts-frontendrendering-codecomponents-customvalidatorimplementations>`
+
+:aspect:`Description`
+      .. include:: ../properties/implementationClassName.rst
+
+
+.. _typo3.cms.form.prototypes.<prototypeidentifier>.validatorsdefinition.filesize.options.minimum:
+
+options.minimum
+---------------
+
+:aspect:`Option path`
+      TYPO3.CMS.Form.prototypes.<prototypeIdentifier>.validatorsDefinition.FileSize.options.minimum
+
+:aspect:`Data type`
+      string
+
+:aspect:`Needed by`
+      Frontend
+
+:aspect:`Mandatory`
+      Yes
+
+:aspect:`Default value (for prototype 'standard')`
+      undefined
+
+:aspect:`Description`
+      The minimum filesize to accep. Use the format <size>B|K|M|G. For exmaple: 10M means 10 Megabytes.
+
+
+.. _typo3.cms.form.prototypes.<prototypeidentifier>.validatorsdefinition.filesize.options.maximum:
+
+options.maximum
+---------------
+
+:aspect:`Option path`
+      TYPO3.CMS.Form.prototypes.<prototypeIdentifier>.validatorsDefinition.FileSize.options.maximum
+
+:aspect:`Data type`
+      string
+
+:aspect:`Needed by`
+      Frontend
+
+:aspect:`Mandatory`
+      Yes
+
+:aspect:`Default value (for prototype 'standard')`
+      undefined
+
+:aspect:`Description`
+      The maximum filesize to accep. Use the format <size>B|K|M|G. For exmaple: 10M means 10 Megabytes.
+
+
+.. _typo3.cms.form.prototypes.<prototypeidentifier>.validatorsdefinition.filesize.formeditor.iconidentifier:
+
+formeditor.iconIdentifier
+-------------------------
+
+:aspect:`Option path`
+      TYPO3.CMS.Form.prototypes.<prototypeIdentifier>.validatorsDefinition.FileSize.formEditor.iconIdentifier
+
+:aspect:`Data type`
+      string
+
+:aspect:`Needed by`
+      Backend (form editor)
+
+:aspect:`Mandatory`
+      Yes
+
+:aspect:`Default value (for prototype 'standard')`
+      .. code-block:: yaml
+         :linenos:
+             :emphasize-lines: 3
+
+             FileSize:
+               formEditor:
+                 iconIdentifier: t3-form-icon-validator
+                 label: formEditor.elements.FileUploadMixin.validators.FileSize.editor.header.label
+
+.. :aspect:`Good to know`
+      ToDo
+
+:aspect:`Description`
+      .. include:: ../properties/iconIdentifier.rst
+
+
+.. _typo3.cms.form.prototypes.<prototypeidentifier>.validatorsdefinition.filesize.formeditor.label:
+
+formeditor.label
+----------------
+
+:aspect:`Option path`
+      TYPO3.CMS.Form.prototypes.<prototypeIdentifier>.validatorsDefinition.FileSize.formEditor.label
+
+:aspect:`Data type`
+      string
+
+:aspect:`Needed by`
+      Backend (form editor)
+
+:aspect:`Mandatory`
+      Yes
+
+:aspect:`Default value (for prototype 'standard')`
+      .. code-block:: yaml
+         :linenos:
+             :emphasize-lines: 4
+
+             FileSize:
+               formEditor:
+                 iconIdentifier: t3-form-icon-validator
+                 label: formEditor.elements.FileUploadMixin.validators.FileSize.editor.header.label
+
+:aspect:`Good to know`
+      - :ref:`"Translate form editor settings"<concepts-formeditor-translation-formeditor>`
+
+:aspect:`Description`
+      .. include:: ../properties/label.rst
+
+
+.. _typo3.cms.form.prototypes.<prototypeidentifier>.validatorsdefinition.filesize.formeditor.predefineddefaults:
+
+formeditor.predefinedDefaults
+-----------------------------
+
+:aspect:`Option path`
+      TYPO3.CMS.Form.prototypes.<prototypeIdentifier>.validatorsDefinition.FileSize.formEditor.predefinedDefaults
+
+:aspect:`Data type`
+      array
+
+:aspect:`Needed by`
+      Backend (form editor)
+
+:aspect:`Mandatory`
+      No
+
+:aspect:`Default value (for prototype 'standard')`
+      .. code-block:: yaml
+         :linenos:
+             :emphasize-lines: 3-
+
+             FileSize:
+               formEditor:
+                 predefinedDefaults:
+                   options:
+                     minimum: '0B'
+                     maximum: '10M'
+
+.. :aspect:`Good to know`
+      ToDo
+
+:aspect:`Description`
+      .. include:: ../properties/predefinedDefaults.rst


### PR DESCRIPTION
A new ExtbaseValidator called "FileSizeValidator" has been added which
is able to validate a file resource regarding its file size. The
validator is also available within the form editor.

Resolves: #82177
Releases: master
Change-Id: I04ae755b8632c473769fc7ae859c97d88c60b390